### PR TITLE
[main] change ICON_BASE_URL to a working address

### DIFF
--- a/contracts/CMakeLists.txt
+++ b/contracts/CMakeLists.txt
@@ -32,7 +32,7 @@ else() # INVALID OR MISMATCH
   )
 endif(VERSION_OUTPUT STREQUAL "MATCH")
 
-set(ICON_BASE_URL "http://127.0.0.1/ricardian_assets/eosio.contracts/icons")
+set(ICON_BASE_URL "https://raw.githubusercontent.com/AntelopeIO/reference-contracts/main/contracts/icons")
 
 set(ACCOUNT_ICON_URI "account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f")
 set(ADMIN_ICON_URI "admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e")


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Change CON_BASE_URL to a working address https://raw.githubusercontent.com/AntelopeIO/reference-contracts/main/contracts/icons (it was http://127.0.0.1/ricardian_assets/eosio.contracts/icons)

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
