### PR TITLE
Replace usage of deque and map with vector in reference contracts

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -435,12 +435,19 @@ namespace eosiosystem {
 
    typedef eosio::multi_index< "rexretpool"_n, rex_return_pool > rex_return_pool_table;
 
+   struct pair_time_point_sec_int64 {
+      time_point_sec first;
+      int64_t        second;
+
+      EOSLIB_SERIALIZE(pair_time_point_sec_int64, (first)(second));
+   };
+
    // `rex_return_buckets` structure underlying the rex return buckets table. A rex return buckets table is defined by:
    // - `version` defaulted to zero,
    // - `return_buckets` buckets of proceeds accumulated in 12-hour intervals
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_buckets {
-      uint8_t                           version = 0;
-      std::map<time_point_sec, int64_t> return_buckets;
+      uint8_t                                version = 0;
+      std::vector<pair_time_point_sec_int64> return_buckets;  // sorted by first field
 
       uint64_t primary_key()const { return 0; }
    };
@@ -473,7 +480,7 @@ namespace eosiosystem {
       asset   vote_stake;
       asset   rex_balance;
       int64_t matured_rex = 0;
-      std::deque<std::pair<time_point_sec, int64_t>> rex_maturities; /// REX daily maturity buckets
+      std::vector<pair_time_point_sec_int64> rex_maturities; /// REX daily maturity buckets
 
       uint64_t primary_key()const { return owner.value; }
    };


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Resolve https://github.com/AntelopeIO/reference-contracts/issues/2

`CDT 3.0.0` introduced nested containers and map handing in ABI generation. It broke reference contracts' ABIs. See description and discussions in https://github.com/AntelopeIO/reference-contracts/issues/2 for details.

This PR replaces the usage of `map` and `deque` with `vector` and produces the same ABIs as prior to `CDT 3.0.0.`

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
