### PR TITLE
add `SYSTEM_ENABLE_LEAP_VERSION_CHECK` & `SYSTEM_ENABLE_CDT_VERSION_CHECK` build knobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ option(SYSTEM_CONFIGURABLE_WASM_LIMITS
 option(SYSTEM_BLOCKCHAIN_PARAMETERS
        "Enables use of the host functions activated by the BLOCKCHAIN_PARAMETERS protocol feature" ON)
 
+option(SYSTEM_ENABLE_LEAP_VERSION_CHECK
+      "Enables a configure-time check that the version of Leap's tester library is compatible with this project's unit tests" ON)
+
+option(SYSTEM_ENABLE_CDT_VERSION_CHECK
+      "Enables a configure-time check that the version of CDT is compatible with this project's contracts" ON)
+
 ExternalProject_Add(
   contracts_project
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/contracts

--- a/contracts/CMakeLists.txt
+++ b/contracts/CMakeLists.txt
@@ -15,22 +15,24 @@ set(CDT_VERSION_SOFT_MAX "4.0")
 # set(CDT_VERSION_HARD_MAX "")
 
 # Check the version of CDT
-set(VERSION_MATCH_ERROR_MSG "")
-CDT_CHECK_VERSION(VERSION_OUTPUT "${CDT_VERSION}" "${CDT_VERSION_MIN}" "${CDT_VERSION_SOFT_MAX}"
-                    "${CDT_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
-if(VERSION_OUTPUT STREQUAL "MATCH")
-  message(STATUS "Using CDT version ${CDT_VERSION}")
-elseif(VERSION_OUTPUT STREQUAL "WARN")
-  message(
-    WARNING
-      "Using CDT version ${CDT_VERSION} even though it exceeds the maximum supported version of ${CDT_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use CDT version ${CDT_VERSION_SOFT_MAX}.x"
-  )
-else() # INVALID OR MISMATCH
-  message(
-    FATAL_ERROR
-      "Found CDT version ${CDT_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use CDT version ${CDT_VERSION_SOFT_MAX}.x"
-  )
-endif(VERSION_OUTPUT STREQUAL "MATCH")
+if(SYSTEM_ENABLE_CDT_VERSION_CHECK)
+  set(VERSION_MATCH_ERROR_MSG "")
+  CDT_CHECK_VERSION(VERSION_OUTPUT "${CDT_VERSION}" "${CDT_VERSION_MIN}" "${CDT_VERSION_SOFT_MAX}"
+                      "${CDT_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
+  if(VERSION_OUTPUT STREQUAL "MATCH")
+    message(STATUS "Using CDT version ${CDT_VERSION}")
+  elseif(VERSION_OUTPUT STREQUAL "WARN")
+    message(
+      WARNING
+        "Using CDT version ${CDT_VERSION} even though it exceeds the maximum supported version of ${CDT_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use CDT version ${CDT_VERSION_SOFT_MAX}.x"
+    )
+  else() # INVALID OR MISMATCH
+    message(
+      FATAL_ERROR
+        "Found CDT version ${CDT_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use CDT version ${CDT_VERSION_SOFT_MAX}.x"
+    )
+  endif(VERSION_OUTPUT STREQUAL "MATCH")
+endif()
 
 set(ICON_BASE_URL "https://raw.githubusercontent.com/AntelopeIO/reference-contracts/main/contracts/icons")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,22 +7,24 @@ set(EOSIO_VERSION_SOFT_MAX "4.1")
 find_package(leap)
 
 # Check the version of Leap
-set(VERSION_MATCH_ERROR_MSG "")
-eosio_check_version(VERSION_OUTPUT "${EOSIO_VERSION}" "${EOSIO_VERSION_MIN}" "${EOSIO_VERSION_SOFT_MAX}"
-                    "${EOSIO_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
-if(VERSION_OUTPUT STREQUAL "MATCH")
-  message(STATUS "Using Leap version ${EOSIO_VERSION}")
-elseif(VERSION_OUTPUT STREQUAL "WARN")
-  message(
-    WARNING
-      "Using Leap version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
-  )
-else() # INVALID OR MISMATCH
-  message(
-    FATAL_ERROR
-      "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
-  )
-endif(VERSION_OUTPUT STREQUAL "MATCH")
+if(SYSTEM_ENABLE_LEAP_VERSION_CHECK)
+  set(VERSION_MATCH_ERROR_MSG "")
+  eosio_check_version(VERSION_OUTPUT "${EOSIO_VERSION}" "${EOSIO_VERSION_MIN}" "${EOSIO_VERSION_SOFT_MAX}"
+                      "${EOSIO_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
+  if(VERSION_OUTPUT STREQUAL "MATCH")
+    message(STATUS "Using Leap version ${EOSIO_VERSION}")
+  elseif(VERSION_OUTPUT STREQUAL "WARN")
+    message(
+      WARNING
+        "Using Leap version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
+    )
+  else() # INVALID OR MISMATCH
+    message(
+      FATAL_ERROR
+        "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
+    )
+  endif(VERSION_OUTPUT STREQUAL "MATCH")
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/contracts.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/contracts.hpp)
 


### PR DESCRIPTION
Bring these two builds knobs over from eos-system-contracts. Needed for building reference-contracts as part of leap's CI so it's not too picky about versions