### PR TITLE
IF: Update for latest IF

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ defaults:
 jobs:
   build-test:
     name: Build & Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup leap-dev & cdt versions
         id: versions

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -29,9 +29,9 @@ void bios::setfinalizer( const finalizer_policy& finalizer_policy ) {
    check(finalizer_policy.finalizers.size() <= max_finalizers, "number of finalizers exceeds the maximum allowed");
    check(finalizer_policy.finalizers.size() > 0, "require at least one finalizer");
 
-   eosio::abi_finalizer_policy abi_finalizer_policy;
-   abi_finalizer_policy.fthreshold = finalizer_policy.threshold;
-   abi_finalizer_policy.finalizers.reserve(finalizer_policy.finalizers.size());
+   eosio::finalizer_policy fin_policy;
+   fin_policy.threshold = finalizer_policy.threshold;
+   fin_policy.finalizers.reserve(finalizer_policy.finalizers.size());
 
    const std::string pk_prefix = "PUB_BLS";
    const std::string sig_prefix = "SIG_BLS";
@@ -75,12 +75,12 @@ void bios::setfinalizer( const finalizer_policy& finalizer_policy ) {
       check(eosio::bls_pop_verify(pk, signature), "proof of possession failed");
 
       std::vector<char> pk_vector(pk.begin(), pk.end());
-      abi_finalizer_policy.finalizers.emplace_back(eosio::abi_finalizer_authority{f.description, f.weight, std::move(pk_vector)});
+      fin_policy.finalizers.emplace_back(eosio::finalizer_authority{f.description, f.weight, std::move(pk_vector)});
    }
 
    check(finalizer_policy.threshold > weight_sum / 2, "finalizer policy threshold must be greater than half of the sum of the weights");
 
-   set_finalizers(std::move(abi_finalizer_policy));
+   set_finalizers(std::move(fin_policy));
 }
 
 void bios::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {

--- a/tests/eosio.bios_inst_fin_tests.cpp
+++ b/tests/eosio.bios_inst_fin_tests.cpp
@@ -54,13 +54,13 @@ BOOST_FIXTURE_TEST_CASE( set_1_finalizer, eosio_bios_if_tester ) try {
     fc::variant pretty_output;
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
 
-    BOOST_REQUIRE(pretty_output.get_object().contains("proposed_finalizer_policy"));
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["generation"], 1);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["fthreshold"], 2);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"].size(), 1u);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"][size_t(0)]["description"], "set_1_finalizer");
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"][size_t(0)]["fweight"], 1);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"][size_t(0)]["public_key"], "PUB_BLS_jpMTmybJZvf4k6fR7Bgu7wrNjwQLK/IBdjhZHWTjoohgdUMi8VpTGsyYpzP1+ekMzUuZ8LqFcnfO0myTwH9Y2YeabhhowSp7nzJJhgO4XWCpcGCLssOjVWh3/D9wMIISVUwfsQ==");
+    BOOST_REQUIRE(pretty_output.get_object().contains("instant_finality_extension"));
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["generation"], 1);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["threshold"], 2);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"].size(), 1u);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(0)]["description"], "set_1_finalizer");
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(0)]["weight"], 1);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(0)]["public_key"], "PUB_BLS_jpMTmybJZvf4k6fR7Bgu7wrNjwQLK/IBdjhZHWTjoohgdUMi8VpTGsyYpzP1+ekMzUuZ8LqFcnfO0myTwH9Y2YeabhhowSp7nzJJhgO4XWCpcGCLssOjVWh3/D9wMIISVUwfsQ==");
 } FC_LOG_AND_RETHROW()
 
 // two finalizers in finalizer policy
@@ -86,13 +86,13 @@ BOOST_FIXTURE_TEST_CASE( set_2_finalizers, eosio_bios_if_tester ) try {
     fc::variant pretty_output;
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
 
-    BOOST_REQUIRE(pretty_output.get_object().contains("proposed_finalizer_policy"));
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["generation"], 1);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["fthreshold"], 4);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"].size(), 2u);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"][size_t(1)]["description"], "set_2_finalizer_2");
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"][size_t(1)]["fweight"], 2);
-    BOOST_REQUIRE_EQUAL(pretty_output["proposed_finalizer_policy"]["finalizers"][size_t(1)]["public_key"], "PUB_BLS_UGcXVpLNrhdODrbI9Geaswu8wFnL+WMnphfTaCgehRxol5wI1qiU5zq6qHp9+CkFnmm2XWCcM/YEtqZYL6uTM1TXTpTm3LODI0s/ULO4iKSNYclsmDdh5cFSMmKKnloHudh3Zw==");
+    BOOST_REQUIRE(pretty_output.get_object().contains("instant_finality_extension"));
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["generation"], 1);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["threshold"], 4);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"].size(), 2u);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(1)]["description"], "set_2_finalizer_2");
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(1)]["weight"], 2);
+    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(1)]["public_key"], "PUB_BLS_UGcXVpLNrhdODrbI9Geaswu8wFnL+WMnphfTaCgehRxol5wI1qiU5zq6qHp9+CkFnmm2XWCcM/YEtqZYL6uTM1TXTpTm3LODI0s/ULO4iKSNYclsmDdh5cFSMmKKnloHudh3Zw==");
 } FC_LOG_AND_RETHROW()
 
 // finalizer cannot be empty

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -1024,9 +1024,9 @@ public:
       }
       produce_blocks( 250 );
 
-      auto producer_keys = control->head_block_state()->active_schedule.producers;
-      BOOST_REQUIRE_EQUAL( 21, producer_keys.size() );
-      BOOST_REQUIRE_EQUAL( name("defproducera"), producer_keys[0].producer_name );
+      auto producer_keys = control->active_producers();
+      BOOST_REQUIRE_EQUAL( 21, producer_keys.producers.size() );
+      BOOST_REQUIRE_EQUAL( name("defproducera"), producer_keys.producers[0].producer_name );
 
       return producer_names;
    }

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -1024,9 +1024,9 @@ public:
       }
       produce_blocks( 250 );
 
-      auto producer_keys = control->active_producers();
-      BOOST_REQUIRE_EQUAL( 21, producer_keys.producers.size() );
-      BOOST_REQUIRE_EQUAL( name("defproducera"), producer_keys.producers[0].producer_name );
+      auto producer_schedule = control->active_producers();
+      BOOST_REQUIRE_EQUAL( 21, producer_schedule.producers.size() );
+      BOOST_REQUIRE_EQUAL( name("defproducera"), producer_schedule.producers[0].producer_name );
 
       return producer_names;
    }

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3187,9 +3187,9 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    //vote for producers
    BOOST_REQUIRE_EQUAL( success(), vote( "alice1111111"_n, { "defproducer1"_n } ) );
    produce_blocks(250);
-   auto producer_keys = control->active_producers();
-   BOOST_REQUIRE_EQUAL( 1, producer_keys.producers.size() );
-   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys.producers[0].producer_name );
+   auto producer_schedule = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 1, producer_schedule.producers.size() );
+   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_schedule.producers[0].producer_name );
 
    //auto config = config_to_variant( control->get_global_properties().configuration );
    //auto prod1_config = testing::filter_fields( config, producer_parameters_example( 1 ) );
@@ -3203,10 +3203,10 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer2"_n } ) );
    ilog(".");
    produce_blocks(250);
-   producer_keys = control->active_producers();
-   BOOST_REQUIRE_EQUAL( 2, producer_keys.producers.size() );
-   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys.producers[0].producer_name );
-   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_keys.producers[1].producer_name );
+   producer_schedule = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 2, producer_schedule.producers.size() );
+   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_schedule.producers[0].producer_name );
+   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_schedule.producers[1].producer_name );
    //config = config_to_variant( control->get_global_properties().configuration );
    //auto prod2_config = testing::filter_fields( config, producer_parameters_example( 2 ) );
    //REQUIRE_EQUAL_OBJECTS(prod2_config, config);
@@ -3214,26 +3214,26 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    // elect 3 producers
    BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer2"_n, "defproducer3"_n } ) );
    produce_blocks(250);
-   producer_keys = control->active_producers();
-   BOOST_REQUIRE_EQUAL( 3, producer_keys.producers.size() );
-   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys.producers[0].producer_name );
-   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_keys.producers[1].producer_name );
-   BOOST_REQUIRE_EQUAL( name("defproducer3"), producer_keys.producers[2].producer_name );
+   producer_schedule = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 3, producer_schedule.producers.size() );
+   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_schedule.producers[0].producer_name );
+   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_schedule.producers[1].producer_name );
+   BOOST_REQUIRE_EQUAL( name("defproducer3"), producer_schedule.producers[2].producer_name );
    //config = config_to_variant( control->get_global_properties().configuration );
    //REQUIRE_EQUAL_OBJECTS(prod2_config, config);
 
    // try to go back to 2 producers and fail
    BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer3"_n } ) );
    produce_blocks(250);
-   producer_keys = control->active_producers();
-   BOOST_REQUIRE_EQUAL( 3, producer_keys.producers.size() );
+   producer_schedule = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 3, producer_schedule.producers.size() );
 
    // The test below is invalid now, producer schedule is not updated if there are
    // fewer producers in the new schedule
    /*
-   BOOST_REQUIRE_EQUAL( 2, producer_keys.size() );
-   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys[0].producer_name );
-   BOOST_REQUIRE_EQUAL( name("defproducer3"), producer_keys[1].producer_name );
+   BOOST_REQUIRE_EQUAL( 2, producer_schedule.size() );
+   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_schedule[0].producer_name );
+   BOOST_REQUIRE_EQUAL( name("defproducer3"), producer_schedule[1].producer_name );
    //config = config_to_variant( control->get_global_properties().configuration );
    //auto prod3_config = testing::filter_fields( config, producer_parameters_example( 3 ) );
    //REQUIRE_EQUAL_OBJECTS(prod3_config, config);

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3187,9 +3187,9 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    //vote for producers
    BOOST_REQUIRE_EQUAL( success(), vote( "alice1111111"_n, { "defproducer1"_n } ) );
    produce_blocks(250);
-   auto producer_keys = control->head_block_state()->active_schedule.producers;
-   BOOST_REQUIRE_EQUAL( 1, producer_keys.size() );
-   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys[0].producer_name );
+   auto producer_keys = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 1, producer_keys.producers.size() );
+   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys.producers[0].producer_name );
 
    //auto config = config_to_variant( control->get_global_properties().configuration );
    //auto prod1_config = testing::filter_fields( config, producer_parameters_example( 1 ) );
@@ -3203,10 +3203,10 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer2"_n } ) );
    ilog(".");
    produce_blocks(250);
-   producer_keys = control->head_block_state()->active_schedule.producers;
-   BOOST_REQUIRE_EQUAL( 2, producer_keys.size() );
-   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys[0].producer_name );
-   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_keys[1].producer_name );
+   producer_keys = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 2, producer_keys.producers.size() );
+   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys.producers[0].producer_name );
+   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_keys.producers[1].producer_name );
    //config = config_to_variant( control->get_global_properties().configuration );
    //auto prod2_config = testing::filter_fields( config, producer_parameters_example( 2 ) );
    //REQUIRE_EQUAL_OBJECTS(prod2_config, config);
@@ -3214,19 +3214,19 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    // elect 3 producers
    BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer2"_n, "defproducer3"_n } ) );
    produce_blocks(250);
-   producer_keys = control->head_block_state()->active_schedule.producers;
-   BOOST_REQUIRE_EQUAL( 3, producer_keys.size() );
-   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys[0].producer_name );
-   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_keys[1].producer_name );
-   BOOST_REQUIRE_EQUAL( name("defproducer3"), producer_keys[2].producer_name );
+   producer_keys = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 3, producer_keys.producers.size() );
+   BOOST_REQUIRE_EQUAL( name("defproducer1"), producer_keys.producers[0].producer_name );
+   BOOST_REQUIRE_EQUAL( name("defproducer2"), producer_keys.producers[1].producer_name );
+   BOOST_REQUIRE_EQUAL( name("defproducer3"), producer_keys.producers[2].producer_name );
    //config = config_to_variant( control->get_global_properties().configuration );
    //REQUIRE_EQUAL_OBJECTS(prod2_config, config);
 
    // try to go back to 2 producers and fail
    BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer3"_n } ) );
    produce_blocks(250);
-   producer_keys = control->head_block_state()->active_schedule.producers;
-   BOOST_REQUIRE_EQUAL( 3, producer_keys.size() );
+   producer_keys = control->active_producers();
+   BOOST_REQUIRE_EQUAL( 3, producer_keys.producers.size() );
 
    // The test below is invalid now, producer schedule is not updated if there are
    // fewer producers in the new schedule


### PR DESCRIPTION
## Change Description

- Changed tests to use `controller::active_producers()`  instead of accessing `block_header_state` directly.
- Changed to new CDT `finalizer_policy` struct

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
