### PR TITLE
update CI to use Ubuntu 22.04 and libtester 5.0 by default, plus update some actions versions

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
    "leap-dev":{
-      "target":"3",
+      "target":"5",
       "prerelease":false
    },
    "cdt":{

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ defaults:
 jobs:
   build-test:
     name: Build & Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup leap-dev & cdt versions
         id: versions
@@ -62,7 +62,7 @@ jobs:
             echo cdt-prerelease=${{inputs.override-cdt-prerelease}} >> $GITHUB_OUTPUT
           fi
       - name: Download cdt
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: cdt
@@ -70,24 +70,22 @@ jobs:
           target: '${{steps.versions.outputs.cdt-target}}'
           prereleases: ${{fromJSON(steps.versions.outputs.cdt-prerelease)}}
           artifact-name: cdt_ubuntu_package_amd64
-          token: ${{github.token}}
       - name: Download leap-dev
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: leap
-          file: 'leap-dev.*(x86_64|amd64).deb'
+          file: 'leap-dev.*ubuntu22\.04_amd64.deb'
           target: '${{steps.versions.outputs.leap-dev-target}}'
           prereleases: ${{fromJSON(steps.versions.outputs.leap-dev-prerelease)}}
-          artifact-name: leap-dev-ubuntu20-amd64
+          artifact-name: leap-dev-ubuntu22-amd64
           container-package: experimental-binaries
-          token: ${{github.token}}
       - name: Install packages
         run: |
           sudo apt install ./*.deb
           sudo apt-get install cmake
           rm ./*.deb
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src
       - name: Build & Test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(EOSIO_VERSION_MIN "3.1")
-set(EOSIO_VERSION_SOFT_MAX "4.1")
+set(EOSIO_VERSION_SOFT_MAX "5.0")
 # set(EOSIO_VERSION_HARD_MAX "")
 
 find_package(leap)


### PR DESCRIPTION
After this change only libtester 5.0+ can be used for testing since only leap 5.0 CI creates a ubuntu 22 libtester.