### PR TITLE
rm platform specific openssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,20 +45,6 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   BUILD_ALWAYS 1)
 
-if(APPLE)
-  set(OPENSSL_ROOT "/usr/local/opt/openssl")
-elseif(UNIX)
-  set(OPENSSL_ROOT "/usr/include/openssl")
-endif()
-set(SECP256K1_ROOT "/usr/local")
-
-if(APPLE)
-  set(OPENSSL_ROOT "/usr/local/opt/openssl")
-elseif(UNIX)
-  set(OPENSSL_ROOT "/usr/include/openssl")
-endif()
-set(SECP256K1_ROOT "/usr/local")
-
 option(BUILD_TESTS "Build unit tests" OFF)
 
 if(BUILD_TESTS)


### PR DESCRIPTION
As of libtester 5.0 these aren't needed.