### PR TITLE
updated to bytes_sold and bytes_purchased

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -548,7 +548,7 @@ namespace eosiosystem {
    struct action_return_sellram {
       name account;
       asset quantity;
-      int64_t bytes;
+      int64_t bytes_sold;
       int64_t ram_bytes;
    };
 
@@ -556,7 +556,7 @@ namespace eosiosystem {
       name payer;
       name receiver;
       asset quantity;
-      int64_t bytes;
+      int64_t bytes_purchased;
       int64_t ram_bytes;
    };
 

--- a/tests/eosio.system_ram_tests.cpp
+++ b/tests/eosio.system_ram_tests.cpp
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_ram_validate, eosio_system_tester ) try {
    "payer": "alice",
    "receiver": "alice",
    "quantity": "0.1462 TST",
-   "bytes": 9991,
+   "bytes_purchased": 9991,
    "ram_bytes": 17983
 }
 )=====";
@@ -92,7 +92,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_ram_validate, eosio_system_tester ) try {
 {
    "account": "alice",
    "quantity": "0.1455 TST",
-   "bytes": 10000,
+   "bytes_sold": 10000,
    "ram_bytes": 7983
 }
 )=====";
@@ -104,7 +104,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_ram_validate, eosio_system_tester ) try {
    "payer": "bob",
    "receiver": "alice",
    "quantity": "2.0000 TST",
-   "bytes": 136750,
+   "bytes_purchased": 136750,
    "ram_bytes": 144733
 }
 )=====";
@@ -130,7 +130,7 @@ BOOST_FIXTURE_TEST_CASE( ram_burn, eosio_system_tester ) try {
    "payer": "bob",
    "receiver": "bob",
    "quantity": "10.0000 TST",
-   "bytes": 683747,
+   "bytes_purchased": 683747,
    "ram_bytes": 691739
 }
 )=====";
@@ -179,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE( buy_ram_self, eosio_system_tester ) try {
    "payer": "alice",
    "receiver": "alice",
    "quantity": "2.0000 TST",
-   "bytes": 136750,
+   "bytes_purchased": 136750,
    "ram_bytes": 213117
 }
 )=====";

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -253,7 +253,7 @@ public:
                      "type": "asset"
                  },
                  {
-                     "name": "bytes",
+                     "name": "bytes_purchased",
                      "type": "int64"
                  },
                  {
@@ -301,7 +301,7 @@ public:
                      "type": "asset"
                  },
                  {
-                     "name": "bytes",
+                     "name": "bytes_sold",
                      "type": "int64"
                  },
                  {


### PR DESCRIPTION
For clarity updates to `bytes_sold` and `bytes_purchased` in `ramsell` and `rambuy` functions. Previous more generic `bytes`. Resolves #52 