### PR TITLE
Version bump to 3.4.0-dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(eosio_contracts)
 
 set(VERSION_MAJOR 3)
-set(VERSION_MINOR 3)
+set(VERSION_MINOR 4)
 set(VERSION_PATCH 0)
 set(VERSION_SUFFIX dev)
 


### PR DESCRIPTION
Bump version in main branch to match next version, `3.4.0-dev`, and to match system contracts 
Fix #54 
