### PR TITLE
IF: change leap-dev target back to hotstuff_integration

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
    "leap-dev":{
-      "target":"pubkey_base64url",
+      "target":"hotstuff_integration",
       "prerelease":false
    },
    "cdt":{


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
https://github.com/AntelopeIO/reference-contracts/pull/56 changed leap-dev target to `pubkey_base64url` temporarily to get around circular dependency between reference contracts and Leap CICD libtester tests for https://github.com/AntelopeIO/leap/pull/2255. This PR changes it back to `hotstuff_integration`. 

The PR  is created in anticipation of approval of https://github.com/AntelopeIO/leap/pull/2255; it will be merged right after https://github.com/AntelopeIO/leap/pull/2255 is merged, to avoid Leap CICD interruptions on `hotstuff_integration` branch. 

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
