### PR TITLE
Ehp/hotstuff integration

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -4,7 +4,7 @@
       "prerelease":false
    },
    "cdt":{
-      "target":"hotstuff_integration",
+      "target":"main",
       "prerelease":false
    }
 }

--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,10 +1,10 @@
 {
    "leap-dev":{
-      "target":"5",
+      "target":"hotstuff_integration",
       "prerelease":false
    },
    "cdt":{
-      "target":"3",
+      "target":"hotstuff_integration",
       "prerelease":false
    }
 }

--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
    "leap-dev":{
-      "target":"hotstuff_integration",
+      "target":"5",
       "prerelease":false
    },
    "cdt":{

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,7 @@ jobs:
           container-package: experimental-binaries
       - name: Install packages
         run: |
+          sudo apt-get update && sudo apt-get upgrade -y
           sudo apt install ./*.deb
           sudo apt-get install cmake
           rm ./*.deb


### PR DESCRIPTION
When CDT `hotstuff_integration` branch was merged into `main` the branch was dereferenced. Now `reference-contracts` CICD tries to target a version of CDT which no longer exists. This PR updates the CDT target. 