### PR TITLE
Tokenomics - REX Upgrade

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -24,6 +24,15 @@
 // be set to 0.
 #define CHANNEL_RAM_AND_NAMEBID_FEES_TO_REX 1
 
+#ifdef MATURED_REX_SOLD_AND_BUY_REX_TO_SAVINGS
+#undef MATURED_REX_SOLD_AND_BUY_REX_TO_SAVINGS
+#endif
+// MATURED_REX_SOLD_AND_BUY_REX_TO_SAVINGS macro determines whether matured REX is sold immediately and buying REX is moved immediately to REX savings.
+// In order to enable this behavior, the macro must be set to 1.
+// https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
+// https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
+#define MATURED_REX_SOLD_AND_BUY_REX_TO_SAVINGS 0
+
 namespace eosiosystem {
 
    using eosio::asset;
@@ -1588,6 +1597,7 @@ namespace eosiosystem {
          int64_t read_rex_savings( const rex_balance_table::const_iterator& bitr );
          void put_rex_savings( const rex_balance_table::const_iterator& bitr, int64_t rex );
          void update_rex_stake( const name& voter );
+         void sell_rex( const name& from, const asset& rex );
 
          void add_loan_to_rex_pool( const asset& payment, int64_t rented_tokens, bool new_loan );
          void remove_loan_from_rex_pool( const rex_loan& loan );

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1588,6 +1588,7 @@ namespace eosiosystem {
          void add_to_rex_return_pool( const asset& fee );
          void process_rex_maturities( const rex_balance_table::const_iterator& bitr );
          void process_sell_matured_rex( const name owner );
+         void process_buy_rex_to_savings( const name owner, const asset rex );
          void consolidate_rex_balance( const rex_balance_table::const_iterator& bitr,
                                        const asset& rex_in_sell_order );
          int64_t read_rex_savings( const rex_balance_table::const_iterator& bitr );

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -891,9 +891,6 @@ namespace eosiosystem {
           * @param from - owner account name,
           * @param amount - amount of tokens taken out of 'from' REX fund.
           *
-          * @pre A voting requirement must be satisfied before action can be executed.
-          * @pre User must vote for at least 21 producers or delegate vote to proxy before buying REX.
-          *
           * @post User votes are updated following this action.
           * @post Tokens used in purchase are added to user's voting power.
           * @post Bought REX cannot be sold before 4 days counting from end of day of purchase.
@@ -909,9 +906,6 @@ namespace eosiosystem {
           * @param receiver - account name that tokens have previously been staked to,
           * @param from_net - amount of tokens to be unstaked from NET bandwidth and used for REX purchase,
           * @param from_cpu - amount of tokens to be unstaked from CPU bandwidth and used for REX purchase.
-          *
-          * @pre A voting requirement must be satisfied before action can be executed.
-          * @pre User must vote for at least 21 producers or delegate vote to proxy before buying REX.
           *
           * @post User votes are updated following this action.
           * @post Tokens used in purchase are added to user's voting power.
@@ -1569,8 +1563,6 @@ namespace eosiosystem {
          void runrex( uint16_t max );
          void update_rex_pool();
          void update_resource_limits( const name& from, const name& receiver, int64_t delta_net, int64_t delta_cpu );
-         void check_voting_requirement( const name& owner,
-                                        const char* error_msg = "must vote for at least 21 producers or for a proxy before buying REX" )const;
          rex_order_outcome fill_rex_order( const rex_balance_table::const_iterator& bitr, const asset& rex );
          asset update_rex_account( const name& owner, const asset& proceeds, const asset& unstake_quant, bool force_vote_update = false );
          void channel_to_rex( const name& from, const asset& amount, bool required = false );

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -933,7 +933,7 @@ namespace eosiosystem {
           *
           * @post User votes are updated following this action.
           * @post Tokens used in purchase are added to user's voting power.
-          * @post Bought REX cannot be sold before 4 days counting from end of day of purchase.
+          * @post Bought REX cannot be sold before {num_of_maturity_buckets} days counting from end of day of purchase.
           */
          [[eosio::action]]
          void buyrex( const name& from, const asset& amount );
@@ -949,7 +949,7 @@ namespace eosiosystem {
           *
           * @post User votes are updated following this action.
           * @post Tokens used in purchase are added to user's voting power.
-          * @post Bought REX cannot be sold before 4 days counting from end of day of purchase.
+          * @post Bought REX cannot be sold before {num_of_maturity_buckets} days counting from end of day of purchase.
           */
          [[eosio::action]]
          void unstaketorex( const name& owner, const name& receiver, const asset& from_net, const asset& from_cpu );
@@ -1078,7 +1078,7 @@ namespace eosiosystem {
          void rexexec( const name& user, uint16_t max );
 
          /**
-          * Consolidate action, consolidates REX maturity buckets into one bucket that can be sold after 4 days
+          * Consolidate action, consolidates REX maturity buckets into one bucket that can be sold after {num_of_maturity_buckets} days
           * starting from the end of the day.
           *
           * @param owner - REX owner account name.
@@ -1090,7 +1090,7 @@ namespace eosiosystem {
           * Mvtosavings action, moves a specified amount of REX into savings bucket. REX savings bucket
           * never matures. In order for it to be sold, it has to be moved explicitly
           * out of that bucket. Then the moved amount will have the regular maturity
-          * period of 4 days starting from the end of the day.
+          * period of {num_of_maturity_buckets} days starting from the end of the day.
           *
           * @param owner - REX owner account name.
           * @param rex - amount of REX to be moved.
@@ -1100,7 +1100,7 @@ namespace eosiosystem {
 
          /**
           * Mvfrsavings action, moves a specified amount of REX out of savings bucket. The moved amount
-          * will have the regular REX maturity period of 4 days.
+          * will have the regular REX maturity period of {num_of_maturity_buckets} days.
           *
           * @param owner - REX owner account name.
           * @param rex - amount of REX to be moved.
@@ -1132,7 +1132,7 @@ namespace eosiosystem {
           *                             https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
           */
          [[eosio::action]]
-         void rexmaturity(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings );
+         void setrexmature(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings );
          
          /**
           * Donatetorex action, donates funds to REX, increases REX pool return buckets

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -413,6 +413,27 @@ icon: @ICON_BASE_URL@/@REX_ICON_URI@
 
 Performs REX maintenance by processing a maximum of {{max}} REX sell orders and expired loans. Any account can execute this action.
 
+<h1 class="contract">setrexmature</h1>
+
+---
+spec_version: "0.2.0"
+title: Set REX Maturity Settings
+summary: 'Sets the options for REX maturity buckets'
+icon: @ICON_BASE_URL@/@REX_ICON_URI@
+---
+
+{{#if num_of_maturity_buckets}}
+  Sets the numbers of maturity buckets to '{{num_of_maturity_buckets}}'
+{{/if}}
+
+{{#if sell_matured_rex}}
+  Sets whether or not to immediately sell matured REX to '{{sell_matured_rex}}'
+{{/if}}
+
+{{#if buy_rex_to_savings}}
+  Sets whether or not to immediately move purchased REX to savings to '{{buy_rex_to_savings}}'
+{{/if}}
+
 <h1 class="contract">rmvproducer</h1>
 
 ---
@@ -489,9 +510,15 @@ summary: '{{nowrap from}} sells {{nowrap rex}} tokens'
 icon: @ICON_BASE_URL@/@REX_ICON_URI@
 ---
 
-{{from}} initiates a sell order to sell {{rex}} tokens at the market exchange rate during the time at which the order is ultimately executed. If {{from}} already has an open sell order in the sell queue, {{rex}} will be added to the amount of the sell order without change the position of the sell order within the queue. Once the sell order is executed, proceeds are added to {{from}}’s REX fund, the value of sold REX tokens is deducted from {{from}}’s vote stake, and votes are updated accordingly.
+The 'rex' parameter no longer has an effect.
 
-Depending on the market conditions, it may not be possible to fill the entire sell order immediately. In such a case, the sell order is added to the back of a sell queue. A sell order at the front of the sell queue will automatically be executed when the market conditions allow for the entire order to be filled. Regardless of the market conditions, the system is designed to execute this sell order within 30 days. {{from}} can cancel the order at any time before it is filled using the cnclrexorder action.
+{{from}} initiates a sell order to sell all of their matured REX tokens at the market exchange rate during the time at which the order is ultimately executed. 
+If {{from}} already has an open sell order in the sell queue, {{rex}} will be added to the amount of the sell order without change the position of the sell order within the queue. 
+Once the sell order is executed, proceeds are added to {{from}}’s REX fund, the value of sold REX tokens is deducted from {{from}}’s vote stake, and votes are updated accordingly.
+
+Depending on the market conditions, it may not be possible to fill the entire sell order immediately. In such a case, the sell order is added to the back of a sell queue. 
+A sell order at the front of the sell queue will automatically be executed when the market conditions allow for the entire order to be filled. Regardless of the market conditions, 
+the system is designed to execute this sell order within 30 days. {{from}} can cancel the order at any time before it is filled using the cnclrexorder action.
 
 <h1 class="contract">setabi</h1>
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -30,7 +30,8 @@ namespace eosiosystem {
     _rexretbuckets(get_self(), get_self().value),
     _rexfunds(get_self(), get_self().value),
     _rexbalance(get_self(), get_self().value),
-    _rexorders(get_self(), get_self().value)
+    _rexorders(get_self(), get_self().value),
+    _rexmaturity(get_self(), get_self().value)
    {
       _gstate  = _global.exists() ? _global.get() : get_default_parameters();
       _gstate2 = _global2.exists() ? _global2.get() : eosio_global_state2{};

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -62,6 +62,8 @@ namespace eosiosystem {
       const asset delta_rex_stake = add_to_rex_balance( from, amount, rex_received );
       runrex(2);
       update_rex_account( from, asset( 0, core_symbol() ), delta_rex_stake );
+      mvtosavings( from, rex_received );
+
       // dummy action added so that amount of REX tokens purchased shows up in action trace
       rex_results::buyresult_action buyrex_act( rex_account, std::vector<eosio::permission_level>{ } );
       buyrex_act.send( rex_received );

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -71,12 +71,7 @@ namespace eosiosystem {
       if ( rex_maturity_state.buy_rex_to_savings ) {
          mvtosavings( from, rex_received );
       }
-
-      // sell any matured REX
-      // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
-      if ( rex_maturity_state.sell_matured_rex ) {
-         process_sell_matured_rex( from );
-      }
+      process_sell_matured_rex( from );
 
       // dummy action added so that amount of REX tokens purchased shows up in action trace
       rex_results::buyresult_action buyrex_act( rex_account, std::vector<eosio::permission_level>{ } );
@@ -124,12 +119,7 @@ namespace eosiosystem {
       if ( rex_maturity_state.buy_rex_to_savings ) {
          mvtosavings( owner, rex_received );
       }
-
-      // sell any matured REX
-      // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
-      if ( rex_maturity_state.sell_matured_rex ) {
-         process_sell_matured_rex( owner );
-      }
+      process_sell_matured_rex( owner );
 
       // dummy action added so that amount of REX tokens purchased shows up in action trace
       rex_results::buyresult_action buyrex_act( rex_account, std::vector<eosio::permission_level>{ } );
@@ -140,13 +130,7 @@ namespace eosiosystem {
    {
       require_auth( from );
       sell_rex( from, rex );
-
-      // sell any remaining matured REX
-      // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
-      const auto rex_maturity_state = _rexmaturity.get_or_default();
-      if ( rex_maturity_state.sell_matured_rex ) {
-         process_sell_matured_rex( from );
-      }
+      process_sell_matured_rex( from );
    }
 
    void system_contract::sell_rex( const name& from, const asset& rex )
@@ -1033,6 +1017,9 @@ namespace eosiosystem {
     */
    void system_contract::process_sell_matured_rex( const name owner )
    {
+      const auto rex_maturity_state = _rexmaturity.get_or_default();
+      if ( rex_maturity_state.sell_matured_rex == false ) return; // skip selling matured REX
+
       const auto itr = _rexbalance.find( owner.value );
       if ( itr->matured_rex > 0 ) {
          sell_rex(owner, asset(itr->matured_rex, rex_symbol));

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -16,7 +16,6 @@ namespace eosiosystem {
 
       check(*num_of_maturity_buckets > 0, "num_of_maturity_buckets must be positive");
       check(*num_of_maturity_buckets <= 30, "num_of_maturity_buckets must be less than or equal to 30");
-      if ( _rexmaturity.exists() && num_of_maturity_buckets ) check(state.num_of_maturity_buckets != *num_of_maturity_buckets, "num_of_maturity_buckets is the same as the current value");
 
       if ( num_of_maturity_buckets ) state.num_of_maturity_buckets = *num_of_maturity_buckets;
       if ( sell_matured_rex ) state.sell_matured_rex = *sell_matured_rex;

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -64,12 +64,7 @@ namespace eosiosystem {
       runrex(2);
       update_rex_account( from, asset( 0, core_symbol() ), delta_rex_stake );
 
-      // buying REX immediately moves to REX savings
-      // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
-      const auto rex_maturity_state = _rexmaturity.get_or_default();
-      if ( rex_maturity_state.buy_rex_to_savings ) {
-         mvtosavings( from, rex_received );
-      }
+      process_buy_rex_to_savings( from, rex_received );
       process_sell_matured_rex( from );
 
       // dummy action added so that amount of REX tokens purchased shows up in action trace
@@ -112,12 +107,7 @@ namespace eosiosystem {
       runrex(2);
       update_rex_account( owner, asset( 0, core_symbol() ), rex_stake_delta - payment, true );
 
-      // unstake to REX immediately moves to REX savings
-      // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
-      const auto rex_maturity_state = _rexmaturity.get_or_default();
-      if ( rex_maturity_state.buy_rex_to_savings ) {
-         mvtosavings( owner, rex_received );
-      }
+      process_buy_rex_to_savings( owner, rex_received );
       process_sell_matured_rex( owner );
 
       // dummy action added so that amount of REX tokens purchased shows up in action trace
@@ -1022,6 +1012,21 @@ namespace eosiosystem {
       const auto itr = _rexbalance.find( owner.value );
       if ( itr->matured_rex > 0 ) {
          sell_rex(owner, asset(itr->matured_rex, rex_symbol));
+      }
+   }
+
+   /**
+    * @brief Move new REX tokens to savings
+    *        https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
+    *
+    * @param owner - owner account name
+    * @param rex - amount of REX tokens to be moved to savings
+    */
+   void system_contract::process_buy_rex_to_savings( const name owner, const asset rex )
+   {
+      const auto rex_maturity_state = _rexmaturity.get_or_default();
+      if ( rex_maturity_state.buy_rex_to_savings && rex.amount > 0 ) {
+         mvtosavings( owner, rex );
       }
    }
 

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -8,6 +8,20 @@ namespace eosiosystem {
    using eosio::token;
    using eosio::seconds;
 
+   void system_contract::rexmaturity(const uint32_t num_of_maturity_buckets)
+   {
+      require_auth(get_self());
+
+      check(num_of_maturity_buckets > 0, "num_of_maturity_buckets must be positive");
+      check(num_of_maturity_buckets <= 30, "num_of_maturity_buckets must be less than or equal to 30");
+
+      auto state = _rexmaturity.get_or_default();
+      if ( _rexmaturity.exists() ) check(state.num_of_maturity_buckets != num_of_maturity_buckets, "num_of_maturity_buckets is the same as the current value");
+
+      state.num_of_maturity_buckets = num_of_maturity_buckets;
+      _rexmaturity.set(state, get_self());
+   }
+
    void system_contract::deposit( const name& owner, const asset& amount )
    {
       require_auth( owner );
@@ -959,9 +973,10 @@ namespace eosiosystem {
     *
     * @return time_point_sec
     */
-   time_point_sec system_contract::get_rex_maturity()
+   time_point_sec system_contract::get_rex_maturity( const name& system_account_name )
    {
-      const uint32_t num_of_maturity_buckets = 5;
+      rex_maturity_singleton _rexmaturity(system_account_name, system_account_name.value);
+      const uint32_t num_of_maturity_buckets = _rexmaturity.get_or_default().num_of_maturity_buckets; // default 5
       static const uint32_t now = current_time_point().sec_since_epoch();
       static const uint32_t r   = now % seconds_per_day;
       static const time_point_sec rms{ now - r + num_of_maturity_buckets * seconds_per_day };

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -57,7 +57,6 @@ namespace eosiosystem {
 
       check( amount.symbol == core_symbol(), "asset must be core token" );
       check( 0 < amount.amount, "must use positive amount" );
-      check_voting_requirement( from );
       transfer_from_fund( from, amount );
       const asset rex_received    = add_to_rex_pool( amount );
       const asset delta_rex_stake = add_to_rex_balance( from, amount, rex_received );
@@ -75,7 +74,6 @@ namespace eosiosystem {
       check( from_net.symbol == core_symbol() && from_cpu.symbol == core_symbol(), "asset must be core token" );
       check( (0 <= from_net.amount) && (0 <= from_cpu.amount) && (0 < from_net.amount || 0 < from_cpu.amount),
              "must unstake a positive amount to buy rex" );
-      check_voting_requirement( owner );
 
       {
          del_bandwidth_table dbw_table( get_self(), owner.value );
@@ -423,19 +421,6 @@ namespace eosiosystem {
       if ( tot_itr->is_empty() ) {
          totals_tbl.erase( tot_itr );
       }
-   }
-
-   /**
-    * @brief Checks if account satisfies voting requirement (voting for a proxy or 21 producers)
-    * for buying REX
-    *
-    * @param owner - account buying or already holding REX tokens
-    * @err_msg - error message
-    */
-   void system_contract::check_voting_requirement( const name& owner, const char* error_msg )const
-   {
-      auto vitr = _voters.find( owner.value );
-      check( vitr != _voters.end() && ( vitr->proxy || 21 <= vitr->producers.size() ), error_msg );
    }
 
    /**

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -8,7 +8,7 @@ namespace eosiosystem {
    using eosio::token;
    using eosio::seconds;
 
-   void system_contract::rexmaturity(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings )
+   void system_contract::setrexmature(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings )
    {
       require_auth(get_self());
 
@@ -945,7 +945,7 @@ namespace eosiosystem {
    }
 
    /**
-    * @brief Calculates maturity time of purchased REX tokens which is 4 days from end
+    * @brief Calculates maturity time of purchased REX tokens which is {num_of_maturity_buckets} days from end
     * of the day UTC
     *
     * @return time_point_sec

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -208,10 +208,6 @@ namespace eosiosystem {
 
       vote_stake_updater( voter_name );
       update_votes( voter_name, proxy, producers, true );
-      auto rex_itr = _rexbalance.find( voter_name.value );
-      if( rex_itr != _rexbalance.end() && rex_itr->rex_balance.amount > 0 ) {
-         check_voting_requirement( voter_name, "voter holding REX tokens must vote for at least 21 producers or for a proxy" );
-      }
    }
 
    void system_contract::voteupdate( const name& voter_name ) {

--- a/tests/eosio.system_rex_matured_tests.cpp
+++ b/tests/eosio.system_rex_matured_tests.cpp
@@ -1,0 +1,60 @@
+#include <boost/test/unit_test.hpp>
+
+#include "eosio.system_tester.hpp"
+
+using namespace eosio_system;
+
+BOOST_AUTO_TEST_SUITE(eosio_system_rex_tests)
+
+bool within_error(int64_t a, int64_t b, int64_t err) { return std::abs(a - b) <= err; };
+bool within_one(int64_t a, int64_t b) { return within_error(a, b, 1); }
+
+BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
+   // @param num_of_maturity_buckets - used to calculate maturity time of purchase REX tokens from end of the day UTC.
+   // @param sell_matured_rex - if true, matured REX is sold immediately.
+   // @param buy_rex_to_savings - if true, buying REX is moved immediately to REX savings.
+   //
+   // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/132
+   // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
+   // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
+   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, true, true ) );
+
+   const int64_t ratio        = 10000;
+   const asset   init_rent    = core_sym::from_string("20000.0000");
+   const asset   init_balance = core_sym::from_string("1000.0000");
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
+   account_name alice = accounts[0], bob = accounts[1];
+   setup_rex_accounts( accounts, init_balance );
+
+   BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( alice, core_sym::from_string("2.5000") ) );
+   BOOST_REQUIRE_EQUAL( success(), mvfrsavings( alice, asset::from_string("25000.0000 REX") ) );
+
+   produce_blocks(2);
+   produce_block(fc::days(5));
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( alice, asset::from_string("25000.0000 REX") ) );
+   produce_block(fc::days(16));
+
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"),     get_sellrex_result( alice, asset::from_string("25000.0000 REX") ) );
+   BOOST_REQUIRE_EQUAL( success(),                           buyrex( alice, core_sym::from_string("13.0000") ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("13.0000"),    get_rex_vote_stake( alice ) );
+   BOOST_REQUIRE_EQUAL( success(),                           buyrex( alice, core_sym::from_string("17.0000") ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("30.0000"),    get_rex_vote_stake( alice ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("970.0000"),   get_rex_fund(alice) );
+   BOOST_REQUIRE_EQUAL( get_rex_balance(alice).get_amount(), ratio * asset::from_string("30.0000 REX").get_amount() );
+   auto rex_pool = get_rex_pool();
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("30.0000"),  rex_pool["total_lendable"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("30.0000"),  rex_pool["total_unlent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("0.0000"),   rex_pool["total_lent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( init_rent,                         rex_pool["total_rent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( get_rex_balance(alice),            rex_pool["total_rex"].as<asset>() );
+
+   // set `buy_rex_to_savings=false` to test buying REX without moving it to REX savings
+   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, true, false ) );
+   BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( bob, core_sym::from_string("2.5000") ) );
+   produce_blocks(2);
+   produce_block(fc::days(21));
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"), get_sellrex_result( bob, asset::from_string("25000.0000 REX") ) );
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/eosio.system_rex_matured_tests.cpp
+++ b/tests/eosio.system_rex_matured_tests.cpp
@@ -84,10 +84,6 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
 
    // 4.1. Test selling less than all their matured rex, and having all of their already matured rex sold regardless
    BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"), get_sellrex_result( mark, asset::from_string("1.0000 REX") ) );
-   BOOST_REQUIRE_EQUAL( get_rex_balance_obj( mark )["vote_stake"].as<asset>(), core_sym::from_string("0.0000") );
-   BOOST_REQUIRE_EQUAL( asset::from_string("10000.0000 REX"), get_buyrex_result( mark, core_sym::from_string("1.0000") ) );
-   BOOST_REQUIRE_EQUAL( success(), mvfrsavings( mark, asset::from_string("10000.0000 REX") ) );
-   // BOOST_REQUIRE_EQUAL( get_rex_balance_obj( mark )["rex_maturities"].get_array()[0].as<time_point>(), get_rex_balance_obj( mark )["matured_rex"].as<time_point>() );
 
    BOOST_REQUIRE_EQUAL( success(), mvfrsavings( david, asset::from_string("10000.0000 REX") ) ); // must move REX from savings to initiate matured REX unstaking process
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( david, asset::from_string("25000.0000 REX") ) ); // already sold when previously buying REX

--- a/tests/eosio.system_rex_matured_tests.cpp
+++ b/tests/eosio.system_rex_matured_tests.cpp
@@ -22,12 +22,13 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
    const int64_t ratio        = 10000;
    const asset   init_rent    = core_sym::from_string("20000.0000");
    const asset   init_balance = core_sym::from_string("1000.0000");
-   const std::vector<account_name> accounts = { "alice"_n, "bob"_n, "charly"_n, "david"_n };
-   account_name alice = accounts[0], bob = accounts[1], charly = accounts[2], david = accounts[3];
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n, "charly"_n, "david"_n, "mark"_n };
+   account_name alice = accounts[0], bob = accounts[1], charly = accounts[2], david = accounts[3], mark = accounts[4];
    setup_rex_accounts( accounts, init_balance );
 
+
    // 1. set `num_of_maturity_buckets=21` to test increasing maturity time of buying REX tokens.
-   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, false, false ) );
+   BOOST_REQUIRE_EQUAL( success(), setrexmature( 21, false, false ) );
    BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( alice, core_sym::from_string("2.5000") ) );
    produce_blocks(2);
    produce_block(fc::days(5));
@@ -42,14 +43,14 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("970.0000"),   get_rex_fund(alice) );
    BOOST_REQUIRE_EQUAL( get_rex_balance(alice).get_amount(), ratio * asset::from_string("30.0000 REX").get_amount() );
    auto rex_pool = get_rex_pool();
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("30.0000"),  rex_pool["total_lendable"].as<asset>() );
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("30.0000"),  rex_pool["total_unlent"].as<asset>() );
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("0.0000"),   rex_pool["total_lent"].as<asset>() );
-   BOOST_REQUIRE_EQUAL( init_rent,                         rex_pool["total_rent"].as<asset>() );
-   BOOST_REQUIRE_EQUAL( get_rex_balance(alice),            rex_pool["total_rex"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("30.0000"),   rex_pool["total_lendable"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("30.0000"),   rex_pool["total_unlent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("0.0000"),    rex_pool["total_lent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( init_rent,                          rex_pool["total_rent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( get_rex_balance(alice),             rex_pool["total_rex"].as<asset>() );
 
-   // 2. set `buy_rex_to_savings=false` to test buying REX without moving it to REX savings
-   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, true, false ) );
+   // 2. set `sell_matured_rex=true` and `buy_rex_to_savings=false` to test buying REX without moving it to REX savings
+   BOOST_REQUIRE_EQUAL( success(), setrexmature( 21, true, false ) );
    BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( bob, core_sym::from_string("2.5000") ) );
    produce_blocks(2);
    produce_block(fc::days(5));
@@ -59,8 +60,8 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( asset::from_string("10000.0000 REX"), get_buyrex_result( bob, core_sym::from_string("1.0000") ) ); // will also triggers sell matured REX
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1.0000"), get_rex_vote_stake( bob ) );
 
-   // 3. set `sell_matured_rex=false` to test selling matured REX
-   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, false, true ) );
+   // 3. set `sell_matured_rex=false` and `buy_rex_to_savings=true` to test selling matured REX
+   BOOST_REQUIRE_EQUAL( success(), setrexmature( 21, false, true ) );
    BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( charly, core_sym::from_string("2.5000") ) ); // when buying REX, it will automatically be moved to REX savings
    BOOST_REQUIRE_EQUAL( success(), mvfrsavings( charly, asset::from_string("25000.0000 REX") ) ); // move REX from savings to initiate matured REX unstaking process
    produce_blocks(2);
@@ -73,12 +74,21 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( init_balance, get_rex_fund( charly ) );
 
    // 4. legacy holders with matured REX
-   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 5, false, false ) );
+   BOOST_REQUIRE_EQUAL( success(), setrexmature( 5, false, false ) );
    BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( david, core_sym::from_string("2.5000") ) ); // legacy 5 days maturity
+   BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( mark, core_sym::from_string("2.5000") ) );
    produce_blocks(2);
    produce_block(fc::days(5));
-   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, true, true ) );
+   BOOST_REQUIRE_EQUAL( success(), setrexmature( 21, true, true ) );
    BOOST_REQUIRE_EQUAL( asset::from_string("10000.0000 REX"), get_buyrex_result( david, core_sym::from_string("1.0000") ) ); // new 21 days maturity & triggers sell matured REX
+
+   // 4.1. Test selling less than all their matured rex, and having all of their already matured rex sold regardless
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"), get_sellrex_result( mark, asset::from_string("1.0000 REX") ) );
+   BOOST_REQUIRE_EQUAL( get_rex_balance_obj( mark )["vote_stake"].as<asset>(), core_sym::from_string("0.0000") );
+   BOOST_REQUIRE_EQUAL( asset::from_string("10000.0000 REX"), get_buyrex_result( mark, core_sym::from_string("1.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), mvfrsavings( mark, asset::from_string("10000.0000 REX") ) );
+   // BOOST_REQUIRE_EQUAL( get_rex_balance_obj( mark )["rex_maturities"].get_array()[0].as<time_point>(), get_rex_balance_obj( mark )["matured_rex"].as<time_point>() );
+
    BOOST_REQUIRE_EQUAL( success(), mvfrsavings( david, asset::from_string("10000.0000 REX") ) ); // must move REX from savings to initiate matured REX unstaking process
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( david, asset::from_string("25000.0000 REX") ) ); // already sold when previously buying REX
    produce_blocks(2);
@@ -89,6 +99,8 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1.0000"), get_sellrex_result( david, asset::from_string("10000.0000 REX") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("0.0000"), get_rex_vote_stake( david ) );
    BOOST_REQUIRE_EQUAL( init_balance, get_rex_fund( david ) );
+
+
 
 } FC_LOG_AND_RETHROW()
 

--- a/tests/eosio.system_rex_matured_tests.cpp
+++ b/tests/eosio.system_rex_matured_tests.cpp
@@ -17,18 +17,18 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
    // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/132
    // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
    // https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
-   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, true, true ) );
 
+   // setup accounts
    const int64_t ratio        = 10000;
    const asset   init_rent    = core_sym::from_string("20000.0000");
    const asset   init_balance = core_sym::from_string("1000.0000");
-   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
-   account_name alice = accounts[0], bob = accounts[1];
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n, "charly"_n, "david"_n };
+   account_name alice = accounts[0], bob = accounts[1], charly = accounts[2], david = accounts[3];
    setup_rex_accounts( accounts, init_balance );
 
+   // 1. set `num_of_maturity_buckets=21` to test increasing maturity time of buying REX tokens.
+   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, false, false ) );
    BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( alice, core_sym::from_string("2.5000") ) );
-   BOOST_REQUIRE_EQUAL( success(), mvfrsavings( alice, asset::from_string("25000.0000 REX") ) );
-
    produce_blocks(2);
    produce_block(fc::days(5));
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( alice, asset::from_string("25000.0000 REX") ) );
@@ -48,12 +48,47 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_matured_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( init_rent,                         rex_pool["total_rent"].as<asset>() );
    BOOST_REQUIRE_EQUAL( get_rex_balance(alice),            rex_pool["total_rex"].as<asset>() );
 
-   // set `buy_rex_to_savings=false` to test buying REX without moving it to REX savings
+   // 2. set `buy_rex_to_savings=false` to test buying REX without moving it to REX savings
    BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, true, false ) );
    BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( bob, core_sym::from_string("2.5000") ) );
    produce_blocks(2);
+   produce_block(fc::days(5));
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( bob, asset::from_string("25000.0000 REX") ) );
+   produce_block(fc::days(16));
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"), get_rex_vote_stake( bob ) );
+   BOOST_REQUIRE_EQUAL( asset::from_string("10000.0000 REX"), get_buyrex_result( bob, core_sym::from_string("1.0000") ) ); // will also triggers sell matured REX
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("1.0000"), get_rex_vote_stake( bob ) );
+
+   // 3. set `sell_matured_rex=false` to test selling matured REX
+   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, false, true ) );
+   BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( charly, core_sym::from_string("2.5000") ) ); // when buying REX, it will automatically be moved to REX savings
+   BOOST_REQUIRE_EQUAL( success(), mvfrsavings( charly, asset::from_string("25000.0000 REX") ) ); // move REX from savings to initiate matured REX unstaking process
+   produce_blocks(2);
+   produce_block(fc::days(5));
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( charly, asset::from_string("25000.0000 REX") ) );
+   produce_block(fc::days(16));
+   BOOST_REQUIRE_EQUAL( success(),  updaterex( charly ) ); // triggers sell matured REX (any REX action causes sell matured REX)
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"), get_sellrex_result( charly, asset::from_string("25000.0000 REX") ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("0.0000"), get_rex_vote_stake( charly ) );
+   BOOST_REQUIRE_EQUAL( init_balance, get_rex_fund( charly ) );
+
+   // 4. legacy holders with matured REX
+   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 5, false, false ) );
+   BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( david, core_sym::from_string("2.5000") ) ); // legacy 5 days maturity
+   produce_blocks(2);
+   produce_block(fc::days(5));
+   BOOST_REQUIRE_EQUAL( success(), rexmaturity( 21, true, true ) );
+   BOOST_REQUIRE_EQUAL( asset::from_string("10000.0000 REX"), get_buyrex_result( david, core_sym::from_string("1.0000") ) ); // new 21 days maturity & triggers sell matured REX
+   BOOST_REQUIRE_EQUAL( success(), mvfrsavings( david, asset::from_string("10000.0000 REX") ) ); // must move REX from savings to initiate matured REX unstaking process
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( david, asset::from_string("25000.0000 REX") ) ); // already sold when previously buying REX
+   produce_blocks(2);
+   produce_block(fc::days(5));
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient available rex"), sellrex( david, asset::from_string("10000.0000 REX") ) ); // 21 day REX not matured yet
+   produce_blocks(2);
    produce_block(fc::days(21));
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"), get_sellrex_result( bob, asset::from_string("25000.0000 REX") ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("1.0000"), get_sellrex_result( david, asset::from_string("10000.0000 REX") ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("0.0000"), get_rex_vote_stake( david ) );
+   BOOST_REQUIRE_EQUAL( init_balance, get_rex_fund( david ) );
 
 } FC_LOG_AND_RETHROW()
 

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -874,6 +874,10 @@ public:
       return push_action( name(owner), "closerex"_n, mvo()("owner", owner) );
    }
 
+   action_result rexmaturity(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings ) {
+      return push_action( "eosio"_n, "rexmaturity"_n, mvo()("num_of_maturity_buckets", num_of_maturity_buckets)("sell_matured_rex", sell_matured_rex)("buy_rex_to_savings", buy_rex_to_savings) );
+   }
+
    fc::variant get_last_loan(bool cpu) {
       vector<char> data;
       const auto& db = control->db();

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -796,13 +796,14 @@ public:
 
    asset get_sellrex_result( const account_name& from, const asset& rex ) {
       auto trace = base_tester::push_action( config::system_account_name, "sellrex"_n, from, mvo()("from", from)("rex", rex) );
-      asset proceeds;
+      asset proceeds = core_sym::from_string("0.0000");
       for ( size_t i = 0; i < trace->action_traces.size(); ++i ) {
          if ( trace->action_traces[i].act.name == "sellresult"_n ) {
+            asset _action_proceeds;
             fc::raw::unpack( trace->action_traces[i].act.data.data(),
                              trace->action_traces[i].act.data.size(),
-                             proceeds );
-            return proceeds;
+                             _action_proceeds );
+            proceeds += _action_proceeds;
          }
       }
       return proceeds;
@@ -930,8 +931,8 @@ public:
       return push_action( name(owner), "closerex"_n, mvo()("owner", owner) );
    }
 
-   action_result rexmaturity(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings ) {
-      return push_action( "eosio"_n, "rexmaturity"_n, mvo()("num_of_maturity_buckets", num_of_maturity_buckets)("sell_matured_rex", sell_matured_rex)("buy_rex_to_savings", buy_rex_to_savings) );
+   action_result setrexmature(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings ) {
+      return push_action( "eosio"_n, "setrexmature"_n, mvo()("num_of_maturity_buckets", num_of_maturity_buckets)("sell_matured_rex", sell_matured_rex)("buy_rex_to_savings", buy_rex_to_savings) );
    }
    
    action_result donatetorex( const account_name& payer, const asset& quantity, const std::string& memo ) {

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -4165,8 +4165,6 @@ BOOST_FIXTURE_TEST_CASE( unstake_buy_rex, eosio_system_tester, * boost::unit_tes
       BOOST_REQUIRE_EQUAL( get_net_limit( alice ),                  init_net_limit + net_stake.get_amount() );
       BOOST_REQUIRE_EQUAL( success(),
                            vote( alice, std::vector<account_name>(producer_names.begin(), producer_names.begin() + 20) ) );
-      BOOST_REQUIRE_EQUAL( wasm_assert_msg("must vote for at least 21 producers or for a proxy before buying REX"),
-                           unstaketorex( alice, alice, net_stake, cpu_stake ) );
       BOOST_REQUIRE_EQUAL( success(),
                            vote( alice, std::vector<account_name>(producer_names.begin(), producer_names.begin() + 21) ) );
       const asset init_eosio_stake_balance = get_balance( "eosio.stake"_n );
@@ -5188,8 +5186,6 @@ BOOST_FIXTURE_TEST_CASE( update_rex, eosio_system_tester, * boost::unit_test::to
       }
    }
 
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg("voter holding REX tokens must vote for at least 21 producers or for a proxy"),
-                        vote( alice, std::vector<account_name>(producer_names.begin(), producer_names.begin() + 20) ) );
    BOOST_REQUIRE_EQUAL( success(),
                         vote( alice, std::vector<account_name>(producer_names.begin(), producer_names.begin() + 21) ) );
 
@@ -5225,8 +5221,6 @@ BOOST_FIXTURE_TEST_CASE( update_rex, eosio_system_tester, * boost::unit_test::to
    BOOST_REQUIRE_EQUAL( success(), sellrex( alice, get_rex_balance( alice ) ) );
    BOOST_REQUIRE_EQUAL( 0,         get_rex_balance( alice ).get_amount() );
    BOOST_REQUIRE_EQUAL( success(), vote( alice, { producer_names[0], producer_names[4] } ) );
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg("must vote for at least 21 producers or for a proxy before buying REX"),
-                        buyrex( alice, core_sym::from_string("1.0000") ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -5530,9 +5524,6 @@ BOOST_FIXTURE_TEST_CASE( b1_vesting, eosio_system_tester ) try {
    
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("b1 can only claim their tokens over 10 years"),
                         unstake( b1, b1, final_amount, final_amount ) );
-
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg("must vote for at least 21 producers or for a proxy before buying REX"),
-                        unstaketorex( b1, b1, final_amount - small_amount, final_amount - small_amount ) );
 
    BOOST_REQUIRE_EQUAL( error("missing authority of eosio"), vote( b1, { }, "proxyaccount"_n ) );
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

REX upgrades related to buying, selling & unstaking REX.

## Deployment Changes
- [x] deployment of `eosio` system contract

## API Changes
- [x] [new ACTION `rexmaturity`](https://github.com/eosnetworkfoundation/eos-system-contracts/issues/132)

```c++
 /**
  * Facilitates the modification of REX maturity buckets
  *
  * @param num_of_maturity_buckets - used to calculate maturity time of purchase REX tokens from end of the day UTC.
  * @param sell_matured_rex - if true, matured REX is sold immediately.
  *                           https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
  * @param buy_rex_to_savings - if true, buying REX is moved immediately to REX savings.
  *                             https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135
  */
 [[eosio::action]]
 void rexmaturity(const std::optional<uint32_t> num_of_maturity_buckets, const std::optional<bool> sell_matured_rex, const std::optional<bool> buy_rex_to_savings );
```

- [x] [new TABLE `rexmaturity`](https://github.com/eosnetworkfoundation/eos-system-contracts/issues/132)

```c++
struct rex_maturity {
  uint32_t num_of_maturity_buckets = 5;
  bool sell_matured_rex = false;
  bool buy_rex_to_savings = false;
};
```

## Documentation Additions
- [x] https://github.com/eosnetworkfoundation/eos-system-contracts/issues/132
- [x] https://github.com/eosnetworkfoundation/eos-system-contracts/issues/133
- [x] https://github.com/eosnetworkfoundation/eos-system-contracts/issues/134
- [x] https://github.com/eosnetworkfoundation/eos-system-contracts/issues/135

## REX Legacy
1. Buy REX => matures in 4 days (earning yield)
2. Can sell REX anytime while holding to matured (liquid) REX
> REX maturing state happens on buying REX

## REX 2.0
1. Buy REX => moves all newly purchased REX to savings
2. To start unstaking, user must call mvfrsaving to start the 21 day unstaking period
3. Once 21 day unstaking period is over, funds are force sold to their user balance (on their next REX action)
> REX maturing after moving from savings
> REX cannot be held in matured (liquid) form

![REX 2 0](https://github.com/AntelopeIO/reference-contracts/assets/550895/0d5dac2e-f71d-4ae3-8a30-4a5cdd604717)

