### PR TITLE
Change new params in logbuyram and logsellram to binary extensions

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1206,7 +1206,8 @@ namespace eosiosystem {
           * @param fee - the fee to be paid for the ram sold.
           */
          [[eosio::action]]
-         void logbuyram( const name& payer, const name& receiver, const asset& quantity, int64_t bytes, int64_t ram_bytes, const asset& fee );
+         void logbuyram( const name& payer, const name& receiver, const asset& quantity, int64_t bytes, int64_t ram_bytes, 
+            const eosio::binary_extension<asset>& fee );
 
          /**
           * Sell ram action, reduces quota by bytes and then performs an inline transfer of tokens
@@ -1228,7 +1229,8 @@ namespace eosiosystem {
           * @param fee - the fee to be paid for the ram sold.
           */
          [[eosio::action]]
-         void logsellram( const name& account, const asset& quantity, int64_t bytes, int64_t ram_bytes, const asset& fee );
+         void logsellram( const name& account, const asset& quantity, int64_t bytes, int64_t ram_bytes, 
+            const eosio::binary_extension<asset>& fee );
 
          /**
           * Transfer ram action, reduces sender's quota by bytes and increase receiver's quota by bytes.

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -100,7 +100,7 @@ namespace eosiosystem {
       return action_return_buyram{ payer, receiver, quant, bytes_out, ram_bytes, fee };
    }
 
-   void system_contract::logbuyram( const name& payer, const name& receiver, const asset& quantity, int64_t bytes, int64_t ram_bytes, const asset& fee ) {
+   void system_contract::logbuyram( const name& payer, const name& receiver, const asset& quantity, int64_t bytes, int64_t ram_bytes, const eosio::binary_extension<asset>& fee ) {
       require_auth( get_self() );
       require_recipient(payer);
       require_recipient(receiver);
@@ -156,7 +156,7 @@ namespace eosiosystem {
       return action_return_sellram{ account, tokens_out, bytes, ram_bytes, asset(fee, core_symbol() ) };
    }
 
-   void system_contract::logsellram( const name& account, const asset& quantity, int64_t bytes, int64_t ram_bytes, const asset& fee ) {
+   void system_contract::logsellram( const name& account, const asset& quantity, int64_t bytes, int64_t ram_bytes, const eosio::binary_extension<asset>& fee ) {
       require_auth( get_self() );
       require_recipient(account);
    }


### PR DESCRIPTION
Previously these params were simply added to the end of the action param list, and tests did not catch the problem because they were only using the new actions and never the old ones. 

This wraps those new parameters in binary extensions so that it won't throw the `assertion failure with message: datastream attempted to read past the end` error.