### PR TITLE
Fix test failures under default Savanna libtester

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
    "spring-dev":{
-      "target":"default_tester",
+      "target":"main",
       "prerelease":false
    },
    "cdt":{

--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
    "spring-dev":{
-      "target":"main",
+      "target":"default_tester",
       "prerelease":false
    },
    "cdt":{

--- a/tests/eosio.bios_inst_fin_tests.cpp
+++ b/tests/eosio.bios_inst_fin_tests.cpp
@@ -16,7 +16,7 @@ using namespace fc;
 using mvo = fc::mutable_variant_object;
 
 // tests for instant finality actions
-class eosio_bios_if_tester : public tester {
+class eosio_bios_if_tester : public tester_not_transition_to_savanna {
 public:
 
    eosio_bios_if_tester() {

--- a/tests/eosio.bios_inst_fin_tests.cpp
+++ b/tests/eosio.bios_inst_fin_tests.cpp
@@ -16,7 +16,7 @@ using namespace fc;
 using mvo = fc::mutable_variant_object;
 
 // tests for instant finality actions
-class eosio_bios_if_tester : public tester_not_transition_to_savanna {
+class eosio_bios_if_tester : public legacy_tester {
 public:
 
    eosio_bios_if_tester() {

--- a/tests/eosio.limitauth_tests.cpp
+++ b/tests/eosio.limitauth_tests.cpp
@@ -26,7 +26,7 @@ inline const auto bob = "bob111111111"_n;
 struct limitauth_tester: eosio_system_tester {
    action_result push_action(name code, name action, permission_level auth, const variant_object& data) {
       try {
-         TESTER::push_action(code, action, {auth}, data);
+         validating_tester::push_action(code, action, {auth}, data);
          return "";
       } catch (const fc::exception& ex) {
          edump((ex.to_detail_string()));

--- a/tests/eosio.powerup_tests.cpp
+++ b/tests/eosio.powerup_tests.cpp
@@ -71,7 +71,12 @@ using namespace eosio_system;
 
 struct powerup_tester : eosio_system_tester {
 
-   powerup_tester() { create_accounts_with_resources({ "eosio.reserv"_n }); }
+   // Use full_except_do_not_transition_to_savanna for now until
+   // https://github.com/AntelopeIO/reference-contracts/issues/91 is resolved
+   powerup_tester()
+   : eosio_system_tester(setup_level::full, setup_policy::full_except_do_not_transition_to_savanna) {
+      create_accounts_with_resources({ "eosio.reserv"_n });
+   }
 
    void start_rex() {
       create_account_with_resources("rexholder111"_n, config::system_account_name, core_sym::from_string("1.0000"),

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -15,17 +15,9 @@ using namespace fc;
 
 using mvo = fc::mutable_variant_object;
 
-#ifndef TESTER
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-#endif
-
 namespace eosio_system {
 
-class eosio_system_tester : public TESTER {
+class eosio_system_tester : public validating_tester {
 public:
 
    void basic_setup() {
@@ -91,7 +83,8 @@ public:
       full
    };
 
-   eosio_system_tester( setup_level l = setup_level::full ) {
+   eosio_system_tester( setup_level l = setup_level::full, setup_policy policy = setup_policy::full )
+   : validating_tester({}, nullptr, policy) {
       if( l == setup_level::none ) return;
 
       basic_setup();
@@ -1315,7 +1308,7 @@ public:
       }
       produce_blocks( 250);
 
-      auto trace_auth = TESTER::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
+      auto trace_auth = validating_tester::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
                                             ("account", name(config::system_account_name).to_string())
                                             ("permission", name(config::active_name).to_string())
                                             ("parent", name(config::owner_name).to_string())

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -843,7 +843,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
 
    produce_block();
    produce_block( fc::minutes(2) );
-   produce_blocks(2);
+   produce_blocks(config::producer_repetitions * 2);
    BOOST_REQUIRE_EQUAL( control->active_producers().version, 1u );
    produce_block();
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "alice1111111"_n );
@@ -901,7 +901,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
 
    produce_block();
    produce_block( fc::minutes(2) );
-   produce_blocks(2);
+   produce_blocks(config::producer_repetitions * 2);
    BOOST_REQUIRE_EQUAL( control->active_producers().version, 2u );
    produce_block();
    BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "alice1111111"_n );
@@ -933,7 +933,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig_transition, eosio_system_tester ) try {
 
    produce_block();
    produce_block( fc::minutes(2) );
-   produce_blocks(2);
+   produce_blocks(config::producer_repetitions * 2);
    BOOST_REQUIRE_EQUAL( control->active_producers().version, 1u );
 
    auto convert_to_block_timestamp = [](const fc::variant& timestamp) -> eosio::chain::block_timestamp_type {
@@ -2924,6 +2924,10 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
 
    BOOST_REQUIRE_EQUAL(success(), vote( "producvoterb"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+21)));
    BOOST_REQUIRE_EQUAL(success(), vote( "producvoterc"_n, vector<account_name>(producer_names.begin(), producer_names.end())));
+
+   int retries = 50;
+   while (produce_block()->producer == config::system_account_name && --retries);
+   BOOST_REQUIRE(retries > 0);
 
    // give a chance for everyone to produce blocks
    {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Default libtester changes to run under Savanna. This exposes several test failures. This PR addresses them:
* `eosio_bios_if_tests/set_1_finalizer` failures due to starting from Savanna tester (should have started from Legacy tester)
* `eosio_system_tests/producer_wtmsig and eosio_system_tests/producer_wtmsig_transition` failures due to proposer schedule algorithm change
* `eosio_system_tests/producer_onblock_check` failures due to proposer schedule algorithm change

Resolves
https://github.com/AntelopeIO/reference-contracts/issues/90
https://github.com/AntelopeIO/reference-contracts/issues/92
https://github.com/AntelopeIO/reference-contracts/issues/93

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
