### PR TITLE
instant_finality_extension renamed to finality_extension

### DIFF
--- a/tests/eosio.bios_inst_fin_tests.cpp
+++ b/tests/eosio.bios_inst_fin_tests.cpp
@@ -55,7 +55,7 @@ BOOST_FIXTURE_TEST_CASE( set_1_finalizer, eosio_bios_if_tester ) try {
     fc::variant pretty_output;
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
 
-    BOOST_REQUIRE(pretty_output.get_object().contains("instant_finality_extension"));
+    BOOST_REQUIRE(pretty_output.get_object().contains("finality_extension"));
     std::string output_json = fc::json::to_pretty_string(pretty_output);
     BOOST_TEST(output_json.find("\"generation\": 1") != std::string::npos);
     BOOST_TEST(output_json.find("\"threshold\": 2") != std::string::npos);
@@ -86,7 +86,7 @@ BOOST_FIXTURE_TEST_CASE( set_2_finalizers, eosio_bios_if_tester ) try {
     fc::variant pretty_output;
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
 
-    BOOST_REQUIRE(pretty_output.get_object().contains("instant_finality_extension"));
+    BOOST_REQUIRE(pretty_output.get_object().contains("finality_extension"));
     std::string output_json = fc::json::to_pretty_string(pretty_output);
     BOOST_TEST(output_json.find("\"generation\": 1") != std::string::npos);
     BOOST_TEST(output_json.find("\"threshold\": 5") != std::string::npos);

--- a/tests/eosio.bios_inst_fin_tests.cpp
+++ b/tests/eosio.bios_inst_fin_tests.cpp
@@ -55,8 +55,8 @@ BOOST_FIXTURE_TEST_CASE( set_1_finalizer, eosio_bios_if_tester ) try {
     fc::variant pretty_output;
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
 
-    BOOST_REQUIRE(pretty_output.get_object().contains("finality_extension"));
     std::string output_json = fc::json::to_pretty_string(pretty_output);
+    BOOST_TEST(output_json.find("finality_extension") != std::string::npos);
     BOOST_TEST(output_json.find("\"generation\": 1") != std::string::npos);
     BOOST_TEST(output_json.find("\"threshold\": 2") != std::string::npos);
     BOOST_TEST(output_json.find("set_1_finalizer") != std::string::npos);
@@ -86,8 +86,8 @@ BOOST_FIXTURE_TEST_CASE( set_2_finalizers, eosio_bios_if_tester ) try {
     fc::variant pretty_output;
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
 
-    BOOST_REQUIRE(pretty_output.get_object().contains("finality_extension"));
     std::string output_json = fc::json::to_pretty_string(pretty_output);
+    BOOST_TEST(output_json.find("finality_extension") != std::string::npos);
     BOOST_TEST(output_json.find("\"generation\": 1") != std::string::npos);
     BOOST_TEST(output_json.find("\"threshold\": 5") != std::string::npos);
     BOOST_TEST(output_json.find("set_2_finalizer_2") != std::string::npos);


### PR DESCRIPTION
## Change Description

`instant_finality_extension` renamed to `finality_extension` in https://github.com/AntelopeIO/spring/pull/364

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
